### PR TITLE
fix: update fitUrl retrieval logic due to iGPSport API change

### DIFF
--- a/sync_igpsport_to_garmin.py
+++ b/sync_igpsport_to_garmin.py
@@ -408,7 +408,11 @@ def collect_activities_to_sync(igpsport_client: IGPSportClient, garmin_client: G
                 continue
             
             # Add to list of activities to sync
-            fit_url = activity.get("fitOssPath")
+            # Modified: Get fitUrl from activity_detail instead of activity due to iGPSport API change
+            fit_url = activity_detail.get("fitUrl")
+            if not fit_url:
+                fit_url = activity.get("fitOssPath")
+
             if not fit_url:
                 logger.warning(f"No FIT file URL for activity {activity_id}")
                 continue


### PR DESCRIPTION
The iGPSport API structure has changed. The FIT file URL is now located in the `fitUrl` field of the activity details.
This commit adds a check for `fitUrl` in activity details, falling back to `fitOssPath` in the activity summary for backward compatibility.